### PR TITLE
Use explicit calls instead of default members

### DIFF
--- a/src/MExcel.bas
+++ b/src/MExcel.bas
@@ -163,7 +163,7 @@ Public Sub FreezeSheetPanes(ByVal sheet As Worksheet, ByVal rowNumber As Long, B
     With sheet
         .Visible = xlSheetVisible
         .Activate
-        .Cells(cellRow, cellColumn).Select
+        .Cells.Item(cellRow, cellColumn).Select
     End With
     
     ActiveWindow.FreezePanes = True
@@ -191,7 +191,7 @@ End Sub
 
 
 'Returns column header as dictionary
-Public Function GetColumnHeaderNumberDictionary(ByVal wsSheet As Worksheet, ByVal headerRowNum As Integer) As Scripting.Dictionary
+Public Function GetColumnHeaderNumberDictionary(ByVal wsSheet As Worksheet, ByVal headerRowNum As Long) As Scripting.Dictionary
 ' =================================================================================================
 ' Description : Returns the header names & column numbers as a dictionary
 '
@@ -212,7 +212,7 @@ Public Function GetColumnHeaderNumberDictionary(ByVal wsSheet As Worksheet, ByVa
     
     'Variable(s) Initialization
     Set headerDictionary = New Scripting.Dictionary
-    Set headerCell = wsSheet.Cells(headerRowNum, 1)
+    Set headerCell = wsSheet.Cells.Item(headerRowNum, 1)
     
     Do While Not IsEmpty(headerCell)
         If headerDictionary.Exists(Trim$(headerCell.value)) Then
@@ -246,7 +246,7 @@ PROC_ERR:
     
 End Function
 
-Public Function GetKeyValueDictionary(ByVal ws As Worksheet, ByVal keyCol As Integer, ByVal valCol As Integer) As Scripting.Dictionary
+Public Function GetKeyValueDictionary(ByVal ws As Worksheet, ByVal keyCol As Long, ByVal valCol As Long) As Scripting.Dictionary
 ' =================================================================================================
 ' Description : Function to return the dictionary containing key value pairs of data in 2 columns
 '
@@ -267,7 +267,7 @@ Public Function GetKeyValueDictionary(ByVal ws As Worksheet, ByVal keyCol As Int
     '----------------------------------------------------------------------------------------------
     
     'Variable(s) Initialization
-    Set rngKey = ws.Cells(1, keyCol)
+    Set rngKey = ws.Cells.Item(1, keyCol)
     Set keyValueDictionary = New Scripting.Dictionary
     
     'Loop through all rng
@@ -296,6 +296,3 @@ PROC_ERR:
     
     
 End Function
-
-
-

--- a/src/MVBAArray.bas
+++ b/src/MVBAArray.bas
@@ -1532,7 +1532,7 @@ PROC_ERR:
 
 End Sub
 
-Public Function StringToArray(ByVal Str As String, _
+Public Function StringToArray(ByVal str As String, _
                      Optional ByVal Delimiter As String = " ", _
                      Optional ByVal Limit As Long = -1, _
                      Optional ByVal Compare _
@@ -1567,7 +1567,7 @@ Public Function StringToArray(ByVal Str As String, _
     ' ---------------
 
     If (Len(Delimiter) > 0) Then
-        vRtn = Split(Str, Delimiter, Limit, Compare)
+        vRtn = Split(str, Delimiter, Limit, Compare)
         GoTo PROC_EXIT
     End If
 
@@ -1577,7 +1577,7 @@ Public Function StringToArray(ByVal Str As String, _
     If (Limit > 0) Then
         lLen = Limit
     Else
-        lLen = Len(Str)
+        lLen = Len(str)
     End If
 
     vRtn = Array()
@@ -1585,7 +1585,7 @@ Public Function StringToArray(ByVal Str As String, _
 
     For lPos = 1 To lLen
         lIdx = lPos - 1
-        vRtn(lIdx) = Mid$(Str, lPos, 1)
+        vRtn(lIdx) = Mid$(str, lPos, 1)
     Next lPos
 
     ' ----------------------------------------------------------------------

--- a/src/MVBAFileSystem.bas
+++ b/src/MVBAFileSystem.bas
@@ -156,4 +156,3 @@ PROC_ERR:
     Resume PROC_EXIT
     
 End Function
-

--- a/src/MVBALogger.bas
+++ b/src/MVBALogger.bas
@@ -200,7 +200,7 @@ Public Sub WriteToLog(ByVal module As String, _
                         ByVal message As String, _
                 Optional ByVal logLevel As LoggingLevel = Information, _
                 Optional ByVal errNumber As Long, _
-                Optional ByVal source As String)
+                Optional ByVal Source As String)
 ' =================================================================================================
 ' Description : Procedure to write to logs
 '
@@ -218,7 +218,7 @@ Public Sub WriteToLog(ByVal module As String, _
 
     Dim computerName        As String
     Dim userName            As String
-    Dim iFileNum            As Integer
+    Dim iFileNum            As Long
     Dim logFile             As String
     Dim logFileHeader       As String
     Dim logMessage          As String
@@ -274,7 +274,7 @@ Public Sub WriteToLog(ByVal module As String, _
                       computerName, _
                       userName, _
                       GetLoglevelDescription(logLevel), _
-                      IIf(Len(source) > 0, source, ThisWorkbook.Name), _
+                      IIf(Len(Source) > 0, Source, ThisWorkbook.Name), _
                       module, _
                       procedure, _
                       logMessage, _
@@ -347,8 +347,3 @@ PROC_ERR:
     
     
 End Function
-
-
-
-
-

--- a/src/MVBAStrings.bas
+++ b/src/MVBAStrings.bas
@@ -135,7 +135,7 @@ Public Function FormatString(ByVal inputString As String, ParamArray replacement
     Const PROCEDURE_NAME As String = "FormatString"
 
     Dim formattedString    As String
-    Dim index As Long
+    Dim Index As Long
     Dim placeholder As String
     Dim replacement As String
 
@@ -146,14 +146,14 @@ Public Function FormatString(ByVal inputString As String, ParamArray replacement
     'Replace all placeholders
     '------------------------
     
-    For index = LBound(replacements) To UBound(replacements)
+    For Index = LBound(replacements) To UBound(replacements)
         
-        placeholder = "{" & index & "}"
-        replacement = replacements(index)
+        placeholder = "{" & Index & "}"
+        replacement = replacements(Index)
         
         formattedString = Replace(formattedString, placeholder, replacement)
         
-    Next index
+    Next Index
 
     '----------------------------------------------------------------------------------------------
     
@@ -161,7 +161,7 @@ Public Function FormatString(ByVal inputString As String, ParamArray replacement
 End Function
 
 
-Public Function Concat(ByVal delimiter As String, ParamArray params() As Variant) As String
+Public Function Concat(ByVal Delimiter As String, ParamArray Params() As Variant) As String
 ' =================================================================================================
 ' Description : Concatenate string values with a delimiter
 '
@@ -180,7 +180,7 @@ Public Function Concat(ByVal delimiter As String, ParamArray params() As Variant
 
     '----------------------------------------------------------------------------------------------
     
-    For Each parameter In params
+    For Each parameter In Params
         
         If Len(sRtn) = 0 Then
             'First item
@@ -189,7 +189,7 @@ Public Function Concat(ByVal delimiter As String, ParamArray params() As Variant
         Else
             'Other Items
             '-----------
-            sRtn = FormatString("{0}{1}{2}", sRtn, delimiter, CStr(parameter))
+            sRtn = FormatString("{0}{1}{2}", sRtn, Delimiter, CStr(parameter))
         End If
         
     Next parameter
@@ -262,4 +262,3 @@ PROC_ERR:
     
 
 End Function
-


### PR DESCRIPTION
Use long instead of integer, Use explicit calls instead of default members